### PR TITLE
Add cast to int when reading port argument

### DIFF
--- a/channels/management/commands/runwsserver.py
+++ b/channels/management/commands/runwsserver.py
@@ -18,7 +18,7 @@ class Command(BaseCommand):
                 "Configure a network-based backend in CHANNEL_BACKENDS to use this command."
             )
         # Run the interface
-        port = options.get("port", None) or 9000
+        port = int(options.get("port", None) or 9000)
         try:
             import asyncio
         except ImportError:


### PR DESCRIPTION
When trying to start `runwsserver` with a port it produced this exception:

```
wsserver_1 |  Running asyncio/Autobahn WebSocket interface server
wsserver_1 |  Channel backend: DatabaseChannelBackend(alias=default)
wsserver_1 | Traceback (most recent call last):
wsserver_1 |   File "./manage.py", line 10, in <module>
wsserver_1 |     execute_from_command_line(sys.argv)
wsserver_1 |   File "/usr/local/lib/python3.4/dist-packages/django/core/management/__init__.py", line 338, in execute_from_command_line
wsserver_1 |     utility.execute()
wsserver_1 |   File "/usr/local/lib/python3.4/dist-packages/django/core/management/__init__.py", line 330, in execute
wsserver_1 |     self.fetch_command(subcommand).run_from_argv(self.argv)
wsserver_1 |   File "/usr/local/lib/python3.4/dist-packages/django/core/management/base.py", line 393, in run_from_argv
wsserver_1 |     self.execute(*args, **cmd_options)
wsserver_1 |   File "/usr/local/lib/python3.4/dist-packages/django/core/management/base.py", line 444, in execute
wsserver_1 |     output = self.handle(*args, **options)
wsserver_1 |   File "/usr/local/lib/python3.4/dist-packages/channels/management/commands/runwsserver.py", line 34, in handle
wsserver_1 |     self.stdout.write(" Listening on: ws://0.0.0.0:%i" % port)
wsserver_1 | TypeError: %i format: a number is required, not str
```

Turned out casting the argument to int fixes it :-)