### PR TITLE
fix uuid generation

### DIFF
--- a/channels/backends/redis_py.py
+++ b/channels/backends/redis_py.py
@@ -32,7 +32,7 @@ class RedisChannelBackend(BaseChannelBackend):
             channel = channel.decode('utf-8')
 
         # Write out message into expiring key (avoids big items in list)
-        key = self.prefix + uuid.uuid4().get_hex()
+        key = self.prefix + str(uuid.uuid4())
         self.connection.set(
             key,
             json.dumps(message),


### PR DESCRIPTION
Another small fix that somehow didn't make it into the last PR (#17)

it caused an `AttributeError: 'UUID' object has no attribute 'get_hex'`