### PR TITLE
keeping the parent class signature

### DIFF
--- a/channels/request.py
+++ b/channels/request.py
@@ -43,5 +43,6 @@ class CustomQueryDict(QueryDict):
     Custom override of QueryDict that sets things directly.
     """
 
-    def __init__(self, values):
+    def __init__(self, values, mutable=False, encoding=None):
+        """ mutable and encoding are ignored :( """
         MultiValueDict.__init__(self, values)


### PR DESCRIPTION
for other frameworks that use it, like the django rest framework