### PR TITLE
Attempted implementation of AsgiRequest._stream

### DIFF
--- a/channels/handler.py
+++ b/channels/handler.py
@@ -9,6 +9,7 @@ from django.core.handlers import base
 from django.core import signals
 from django.core.urlresolvers import set_script_prefix
 from django.utils.functional import cached_property
+from django.utils import six
 
 logger = logging.getLogger('django.request')
 
@@ -78,6 +79,7 @@ class AsgiRequest(http.HttpRequest):
                 # Exit loop if this was the last
                 if not chunk.get("more_content", False):
                     break
+        self._stream = six.BytesIO(self._body)
         # Other bits
         self.resolver_match = None
 

--- a/channels/tests/test_handler.py
+++ b/channels/tests/test_handler.py
@@ -1,0 +1,15 @@
+# -*- coding: utf-8 -*-
+
+from django.test import TestCase
+
+from ..handler import AsgiRequest
+from ..message import Message
+
+
+class TestAsgiRequest(TestCase):
+
+    def test_stream_is_readable(self):
+        text = '...'
+        message = Message({text: text}, None, None)
+        request = AsgiRequest(message)
+        self.assertEqual(request.read(), text)

--- a/channels/tests/test_handler.py
+++ b/channels/tests/test_handler.py
@@ -1,15 +1,21 @@
 # -*- coding: utf-8 -*-
 
 from django.test import TestCase
+try:
+    from unittest import mock
+except ImportError:
+    import mock
 
 from ..handler import AsgiRequest
-from ..message import Message
 
 
 class TestAsgiRequest(TestCase):
 
     def test_stream_is_readable(self):
-        text = '...'
-        message = Message({text: text}, None, None)
+        body = b'...'
+        message = {"body": body,
+                   "reply_channel": mock.Mock(),
+                   "path": "/",
+                   "method": "POST"}
         request = AsgiRequest(message)
-        self.assertEqual(request.read(), text)
+        self.assertEqual(request.read(), body)


### PR DESCRIPTION
This is the beginning of an attempt to fix #32. It isn't working. This PR is just for the sake of discussion. 

The test I added surfaces an issue I mentioned in #66. `AsgiRequest` uses `dict`-style access on `Message`, but `Message` does not support it. See below. This could be because my test is wrong.

```
$ python runtests.py 
Creating test database for alias 'default'...
EEE
======================================================================
ERROR: test_stream_is_readable (channels.tests.test_handler.TestAsgiRequest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/Users/dan/src/channels/channels/tests/test_handler.py", line 14, in test_stream_is_readable
    request = AsgiRequest(message)
  File "/Users/dan/src/channels/channels/handler.py", line 25, in __init__
    self.reply_channel = self.message['reply_channel']
TypeError: 'Message' object is not subscriptable
```