### PR TITLE
MUST is preferable to SHOULD

### DIFF
--- a/docs/asgi.rst
+++ b/docs/asgi.rst
@@ -104,9 +104,9 @@ and underscores (``_``), plus an optional prefix character (see below).
 
 Channels are a first-in, first out queue with at-most-once delivery
 semantics. They can have multiple writers and multiple readers; only a single
-reader should get each written message. Implementations should never
-deliver a message more than once or to more than one reader, and should
-drop messages if this is necessary to achieve this restriction.
+reader should get each written message. Implementations must never deliver
+a message more than once or to more than one reader, and must drop messages if
+this is necessary to achieve this restriction.
 
 In order to aid with scaling and network architecture, a distinction
 is made between channels that have multiple readers (such as the
@@ -259,7 +259,7 @@ receive messages in channel order.
 Specification Details
 =====================
 
-A *channel layer* should provide an object with these attributes
+A *channel layer* must provide an object with these attributes
 (all function arguments are positional):
 
 * ``send(channel, message)``, a callable that takes two arguments; the
@@ -408,10 +408,10 @@ different requests on the same connection different reply channels, and
 correctly multiplex the responses back into the same stream as they come in.
 The HTTP version is available as a string in the request message.
 
-HTTP/2 Server Push responses are included, but should be sent prior to the
-main response, and you should check for ``http_version = 2`` before sending
-them; if a protocol server or connection incapable of Server Push receives
-these, it should simply drop them.
+HTTP/2 Server Push responses are included, but must be sent prior to the
+main response, and applications must check for ``http_version = 2`` before
+sending them; if a protocol server or connection incapable of Server Push
+receives these, it must drop them.
 
 The HTTP specs are somewhat vague on the subject of multiple headers;
 RFC7230 explicitly says they must be merge-able with commas, while RFC6265


### PR DESCRIPTION
This is a good rule with specifications more generally: avoid using should where you can use must. Optional functionality is always tricky, and having "core protocol" things be optional is rarely a good idea.