### PR TITLE
Test against python3.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 language: python
 python:
   - "2.7"
+  - "3.4"
   - "3.5"
 install: pip install tox-travis
 script: tox

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 skipsdist = True
 envlist =
     {py27}-django-{17,18,19}
+    {py34}-django-{18,19}
     {py35}-django-{18,19}
     {py27,py35}-flake8
     isort


### PR DESCRIPTION
Python 3.5 is not available for the current stable version of Debian (Jessie). The next release (Stretch) has not yet been scheduled. Therefore Python 3.4 will be relevant for a good bit longer.