### PR TITLE
Remove references to Django project name

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -64,7 +64,7 @@ Here's what that looks like::
     # In routing.py
     from channels.routing import route
     channel_routing = [
-        route("http.request", "myproject.myapp.consumers.http_consumer"),
+        route("http.request", "myapp.consumers.http_consumer"),
     ]
 
 .. warning::
@@ -113,7 +113,7 @@ Hook it up to the ``websocket.receive`` channel like this::
 
     # In routing.py
     from channels.routing import route
-    from myproject.myapp.consumers import ws_message
+    from myapp.consumers import ws_message
 
     channel_routing = [
         route("websocket.receive", ws_message),
@@ -213,7 +213,7 @@ get the message. Here's all the code::
 And what our routing should look like in ``routing.py``::
 
     from channels.routing import route
-    from myproject.myapp.consumers import ws_add, ws_message, ws_disconnect
+    from myapp.consumers import ws_add, ws_message, ws_disconnect
 
     channel_routing = [
         route("websocket.connect", ws_add),


### PR DESCRIPTION
This PR updates the "Getting started" docs to match the standard Django package layout, rather than importing local apps from the project package. 

While I was following the instructions I ran into the following configuration error:
```
django.core.exceptions.ImproperlyConfigured: Cannot import consumer 'myproject.myapp.consumers.http_consumer'
```
The more common project structure would have `myapp` at the same level as `myproject` so the import path would be just `myapp.consumers.http_consumer`.