### PR TITLE
Browser based basic test

### DIFF
--- a/testproject/chtest/consumers.py
+++ b/testproject/chtest/consumers.py
@@ -12,11 +12,16 @@ def ws_connect(message):
     logger.debug("Received ws connect")
     path = message.content['path']
     if path.endswith("group/"):
+        logger.debug("Connect request for group channel, adding to group channel")
         Group(TEST_GROUP).add(message.reply_channel)
 
 
 def ws_disconnect(message):
     logger.debug("Received ws disconnect")
+    path = message.content['path']
+    if path.endswith("group/"):
+        logger.debug("Disconnect request for group channel, removing from group channel")
+        Group(TEST_GROUP).discard(message.reply_channel)
 
 
 def ws_message(message):
@@ -29,10 +34,10 @@ def ws_message(message):
         logger.debug("Message is on group channel, going to send a response to the group...")
         message.reply_channel.send({'content': 'Message received on group channel, sening response to group'})
         Group(TEST_GROUP).send({
-            'content': "Message to group: {}".format(
-                message.content
-            )
+            'text': message.content['text']
         })
     else:
         logger.debug("Message received on echo channel, sending echo..")
-        message.reply_channel.send(message.content)
+        message.reply_channel.send(
+            {'text': message.content['text']}
+        )

--- a/testproject/chtest/consumers.py
+++ b/testproject/chtest/consumers.py
@@ -1,12 +1,7 @@
-from channels.sessions import enforce_ordering
-
-
-#@enforce_ordering(slight=True)
 def ws_connect(message):
     pass
 
 
-#@enforce_ordering(slight=True)
 def ws_message(message):
     "Echoes messages back to the client"
     message.reply_channel.send(message.content)

--- a/testproject/chtest/consumers.py
+++ b/testproject/chtest/consumers.py
@@ -1,7 +1,38 @@
+import logging
+
+from channels import Group
+
+logger = logging.getLogger(__name__)
+
+
+TEST_GROUP = "test-group"
+
+
 def ws_connect(message):
-    pass
+    logger.debug("Received ws connect")
+    path = message.content['path']
+    if path.endswith("group/"):
+        Group(TEST_GROUP).add(message.reply_channel)
+
+
+def ws_disconnect(message):
+    logger.debug("Received ws disconnect")
 
 
 def ws_message(message):
-    "Echoes messages back to the client"
-    message.reply_channel.send(message.content)
+    """Echoes messages back to the client"""
+    logger.debug("Received ws message: {}".format(message))
+
+    path = message.content['path']
+
+    if path.endswith("group/"):
+        logger.debug("Message is on group channel, going to send a response to the group...")
+        message.reply_channel.send({'content': 'Message received on group channel, sening response to group'})
+        Group(TEST_GROUP).send({
+            'content': "Message to group: {}".format(
+                message.content
+            )
+        })
+    else:
+        logger.debug("Message received on echo channel, sending echo..")
+        message.reply_channel.send(message.content)

--- a/testproject/chtest/templates/chtest/base.html
+++ b/testproject/chtest/templates/chtest/base.html
@@ -1,0 +1,15 @@
+<html>
+
+<script>
+  var socket = new WebSocket("ws://127.0.0.1:8000/asdasd");
+
+  socket.onopen = function() {
+      console.log("Sending hello world");
+      socket.send("hello world");
+  }
+  socket.onmessage = function(e) {
+    console.log("Got a message: " + e);
+  }
+</script>
+
+</html>

--- a/testproject/chtest/templates/chtest/base.html
+++ b/testproject/chtest/templates/chtest/base.html
@@ -5,11 +5,12 @@
   var echo_socket = new WebSocket("ws://127.0.0.1:8000/echo");
 
   echo_socket.onopen = function() {
-      console.log("Sending hello world, expecting a response back...");
-      echo_socket.send("hello world");
+    var echo_msg = "Hello world";
+    console.log("Sending '" + echo_msg + "', expecting a response back...");
+    echo_socket.send(echo_msg);
   }
   echo_socket.onmessage = function(e) {
-    console.log("Got a message response on echo socket: " + e);
+    console.log("Got a message response on echo socket: " + e.data);
   }
 </script>
 

--- a/testproject/chtest/templates/chtest/base.html
+++ b/testproject/chtest/templates/chtest/base.html
@@ -1,15 +1,27 @@
 <html>
+<body>
 
 <script>
-  var socket = new WebSocket("ws://127.0.0.1:8000/asdasd");
+  var echo_socket = new WebSocket("ws://127.0.0.1:8000/echo");
 
-  socket.onopen = function() {
-      console.log("Sending hello world");
-      socket.send("hello world");
+  echo_socket.onopen = function() {
+      console.log("Sending hello world, expecting a response back...");
+      echo_socket.send("hello world");
   }
-  socket.onmessage = function(e) {
-    console.log("Got a message: " + e);
+  echo_socket.onmessage = function(e) {
+    console.log("Got a message response on echo socket: " + e);
   }
 </script>
+
+
+{% block content %}
+
+<h1>Test page</h1>
+
+Please open a javascript console to see log output.
+
+{% endblock %}
+
+</body>
 
 </html>

--- a/testproject/chtest/templates/chtest/group.html
+++ b/testproject/chtest/templates/chtest/group.html
@@ -9,11 +9,12 @@ This page opens a group socket, sends a message to it and expects a reply back. 
   var group_socket = new WebSocket("ws://127.0.0.1:8000/group/");
 
   group_socket.onopen = function() {
-      console.log("Connected to group socket, sending a hello, expecting a response...");
-      group_socket.send("Hello group");
+      var group_msg = "Hello group";
+      console.log("Connected to group socket, sending '" + group_msg + "', expecting to see this message appear in the group socket to everyone...");
+      group_socket.send(group_msg);
   }
   group_socket.onmessage = function(e) {
-    console.log("Got a message from group: " + e);
+    console.log("Got a message from group socket: " + e.data);
   }
 </script>
 

--- a/testproject/chtest/templates/chtest/group.html
+++ b/testproject/chtest/templates/chtest/group.html
@@ -1,0 +1,21 @@
+{% extends "chtest/base.html" %}
+{% block content %}
+
+<h1>Group test</h1>
+
+This page opens a group socket, sends a message to it and expects a reply back. Please open up a javascript console.
+
+<script>
+  var group_socket = new WebSocket("ws://127.0.0.1:8000/group/");
+
+  group_socket.onopen = function() {
+      console.log("Connected to group socket, sending a hello, expecting a response...");
+      group_socket.send("Hello group");
+  }
+  group_socket.onmessage = function(e) {
+    console.log("Got a message from group: " + e);
+  }
+</script>
+
+{% endblock %}
+

--- a/testproject/chtest/views.py
+++ b/testproject/chtest/views.py
@@ -9,3 +9,8 @@ def plain_text(request):
 def websocket_test(request):
 
     return render_to_response("chtest/base.html")
+
+
+def group_test(request):
+
+    return render_to_response("chtest/group.html")

--- a/testproject/chtest/views.py
+++ b/testproject/chtest/views.py
@@ -1,5 +1,11 @@
 from django.http import HttpResponse
+from django.shortcuts import render_to_response
 
 
-def index(request):
+def plain_text(request):
     return HttpResponse("OK")
+
+
+def websocket_test(request):
+
+    return render_to_response("chtest/base.html")

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -26,6 +26,30 @@ TEMPLATES = [
     },
 ]
 
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': True,
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+        },
+    },
+    'loggers': {
+        'django.request': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if DEBUG else 'INFO',
+        },
+        'chtest': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if DEBUG else 'INFO',
+        },
+        'django.channels': {
+            'handlers': ['console'],
+            'level': 'DEBUG' if DEBUG else 'INFO',
+        },
+    },
+}
+
 STATIC_URL = "/static/"
 
 DATABASES = {

--- a/testproject/testproject/settings.py
+++ b/testproject/testproject/settings.py
@@ -12,11 +12,19 @@ INSTALLED_APPS = (
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'channels',
+    'chtest',
 )
 
 ROOT_URLCONF = 'testproject.urls'
 
 WSGI_APPLICATION = 'testproject.wsgi.application'
+
+TEMPLATES = [
+    {
+        'BACKEND': 'django.template.backends.django.DjangoTemplates',
+        'APP_DIRS': True,
+    },
+]
 
 STATIC_URL = "/static/"
 
@@ -29,10 +37,12 @@ DATABASES = {
 
 CHANNEL_LAYERS = {
     "default": {
-        "BACKEND": "asgi_redis.RedisChannelLayer",
+        "BACKEND": "asgiref.inmemory.ChannelLayer",
         "ROUTING": "testproject.urls.channel_routing",
-        "CONFIG": {
-            "hosts": [os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')],
-        }
+        # Use this for Redis testing
+        # "BACKEND": "asgi_redis.RedisChannelLayer",
+        # "CONFIG": {
+        #     "hosts": [os.environ.get('REDIS_URL', 'redis://127.0.0.1:6379')],
+        # }
     },
 }

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -4,6 +4,7 @@ from chtest import consumers, views
 
 urlpatterns = [
     url(r'^$', views.websocket_test),
+    url(r'^group/$', views.group_test),
     url(r'^plain-text/$', views.plain_text),
 ]
 
@@ -11,4 +12,5 @@ urlpatterns = [
 channel_routing = {
     "websocket.receive": consumers.ws_message,
     "websocket.connect": consumers.ws_connect,
+    "websocket.disconnect": consumers.ws_disconnect,
 }

--- a/testproject/testproject/urls.py
+++ b/testproject/testproject/urls.py
@@ -1,9 +1,10 @@
-from django.conf.urls import  url
+from django.conf.urls import url
 from chtest import consumers, views
 
 
 urlpatterns = [
-    url(r'^$', views.index),
+    url(r'^$', views.websocket_test),
+    url(r'^plain-text/$', views.plain_text),
 ]
 
 


### PR DESCRIPTION
As discussed on IRC #django-channels, ~~here is a proof of concept that `Group.send` on inmemory backend does not work atm.~~

Recreating:

1. Go to `testproject`, `python manage runserver`
1. Navigate to the basic echo test: http://127.0.0.1:8000/ - it works! Reply received.
1. Navigate to the group test: http://127.0.0.1:8000/group/ - that also works!
