### PR TITLE
django session must be JSON serializable

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -350,7 +350,9 @@ name in the path of your WebSocket request (we'll ignore auth for now - that's n
     @channel_session
     def ws_connect(message):
         # Work out room name from path (ignore slashes)
-        room = message.content['path'].strip("/")
+        room = message.content['path'].strip(b"/")
+        # django session must be JSON serializable as `bytes` are not
+        room = room.decode('utf-8')
         # Save room in session and add us to the group
         message.channel_session['room'] = room
         Group("chat-%s" % room).add(message.reply_channel)


### PR DESCRIPTION
Problem 1: 

`message.content['path']` is of type `bytes`, thus bytes-like object is required to strip it

Problem 2:

example traceback:

```
Traceback (most recent call last):
  File "/vagrant/env/lib/python3.5/site-packages/channels/worker.py", line 78, in run
    consumer(message, **kwargs)
  File "/vagrant/env/lib/python3.5/site-packages/channels/sessions.py", line 65, in inner
    session.save()
  File "/vagrant/env/lib/python3.5/site-packages/django/contrib/sessions/backends/db.py", line 82, in save
    obj = self.create_model_instance(data)
  File "/vagrant/env/lib/python3.5/site-packages/django/contrib/sessions/backends/db.py", line 68, in create_model_instance
    session_data=self.encode(data),
  File "/vagrant/env/lib/python3.5/site-packages/django/contrib/sessions/backends/base.py", line 88, in encode
    serialized = self.serializer().dumps(session_dict)
  File "/vagrant/env/lib/python3.5/site-packages/django/core/signing.py", line 95, in dumps
    return json.dumps(obj, separators=(',', ':')).encode('latin-1')
  File "/usr/lib/python3.5/json/__init__.py", line 237, in dumps
    **kw).encode(obj)
  File "/usr/lib/python3.5/json/encoder.py", line 199, in encode
    chunks = self.iterencode(o, _one_shot=True)
  File "/usr/lib/python3.5/json/encoder.py", line 257, in iterencode
    return _iterencode(o, 0)
  File "/usr/lib/python3.5/json/encoder.py", line 180, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: b'chat' is not JSON serializable
```

django session needs a JSON serializable object, and `bytes` are not, thus we need to decode bytes object into str.

Probably `room = room.decode()` and `room = str(room)` are equivalent fixes.