### PR TITLE
pass arguments to get_consumer

### DIFF
--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -36,7 +36,7 @@ class Command(RunserverCommand):
         # Check a handler is registered for http reqs; if not, add default one
         self.channel_layer = channel_layers[DEFAULT_CHANNEL_LAYER]
         self.channel_layer.router.check_default(
-            http_consumer=self.get_consumer(),
+            http_consumer=self.get_consumer(*args, **options),
         )
         # Run checks
         self.stdout.write("Performing system checks...\n\n")


### PR DESCRIPTION
if args/options are not passed, get_consumer will always get an empty options dict, resulting in broken calls to options.get('use_static_handler', True) and options.get('insecure_serving', False)