### PR TITLE
Remove unused 'Group' import from tutorial

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -100,7 +100,6 @@ serve HTTP requests from now on, which happens if you don't specify a consumer
 for ``http.request`` - and make this WebSocket consumer instead::
 
     # In consumers.py
-    from channels import Group
 
     def ws_message(message):
         # ASGI WebSocket packet-received and send-packet message types


### PR DESCRIPTION
Was this supposed to be here? It isn't used until the next section.