### PR TITLE
[doc] Channel.send() has no parameter `id`

### DIFF
--- a/docs/concepts.rst
+++ b/docs/concepts.rst
@@ -184,7 +184,6 @@ set of channels (here, using Redis) to send updates to::
         # Loop through all response channels and send the update
         for reply_channel in redis_conn.smembers("readers"):
             Channel(reply_channel).send(
-                id=instance.id,
                 content=instance.content,
             )
 


### PR DESCRIPTION
See https://github.com/andrewgodwin/channels/blob/80a9019cb24ea581a9cef0344caaf4cec4a95a94/channels/channel.py#L32