### PR TITLE
Using logger.error instead of logger.exception

### DIFF
--- a/channels/worker.py
+++ b/channels/worker.py
@@ -96,7 +96,7 @@ class Worker(object):
             # Handle the message
             match = self.channel_layer.router.match(message)
             if match is None:
-                logger.exception("Could not find match for message on %s! Check your routing.", channel)
+                logger.error("Could not find match for message on %s! Check your routing.", channel)
                 continue
             else:
                 consumer, kwargs = match


### PR DESCRIPTION
https://docs.python.org/2.7/library/logging.html#logging.Logger.exception 

> .. This method should only be called from an exception handler.

