### PR TITLE
Fix for apply_routes: wrap routes in list, if it is not so

### DIFF
--- a/channels/tests/base.py
+++ b/channels/tests/base.py
@@ -157,7 +157,8 @@ class apply_routes(object):
                     routes = list(map(include, self.routes))
                 else:
                     routes = self.routes
-
+            else:
+                routes = [self.routes]
             channel_layer.routing = routes
             channel_layer.router = Router(routes)
 


### PR DESCRIPTION
Fixing undefined error for cases like this:

```python
with apply_routes(route_class(MyConsumers)):
    ...
```

Maybe it will be useful.