### PR TITLE
Update channels test readme

### DIFF
--- a/testproject/Dockerfile
+++ b/testproject/Dockerfile
@@ -2,10 +2,10 @@ FROM ubuntu:16.04
 
 MAINTAINER Andrew Godwin <andrew@aeracode.org>
 
+# python-dev \
 RUN apt-get update && \
     apt-get install -y \
         git \
-        python-dev \
         python-setuptools \
         python-pip && \
     pip install -U pip

--- a/testproject/README.rst
+++ b/testproject/README.rst
@@ -3,3 +3,41 @@ Channels Test Project
 
 This subdirectory contains benchmarking code and a companion Django project
 that can be used to benchmark Channels for both HTTP and WebSocket performance.
+
+Preparation:
+~~~~~~~~~~~~
+
+    Set up a Python 2.7 virtualenv however you do that and activate it.
+
+    e.g. to create it right in the test directory (assuming python 2 is your system's default)::
+
+        virtualenv channels-test-py27
+        source channels-test-py27/bin/activate
+        pip install -U -r requirements.txt
+
+How to use:
+~~~~~~~~~~~
+
+    Build the docker image from Dockerfile, tag it `channels-test`::
+
+        docker build -t channels-test .
+
+    Run the server::
+
+        docker-compose up -d
+
+    The benchmark project will now be running on: http:{your-docker-ip}:80
+
+    Test it by navigating to that address in a browser.  It should just say "OK".
+
+    Run the benchmark's help to show the parameters::
+
+        python benchmark.py --help
+
+    Let's just try a quick test with the default values from the parameter list::
+
+        python benchmark.py ws://localhost:80
+
+
+
+

--- a/testproject/README.rst
+++ b/testproject/README.rst
@@ -15,8 +15,8 @@ Preparation:
         source channels-test-py27/bin/activate
         pip install -U -r requirements.txt
 
-How to use:
-~~~~~~~~~~~
+How to use with Docker:
+~~~~~~~~~~~~~~~~~~~~~~~
 
     Build the docker image from Dockerfile, tag it `channels-test`::
 
@@ -26,9 +26,11 @@ How to use:
 
         docker-compose up -d
 
-    The benchmark project will now be running on: http:{your-docker-ip}:80
+    The benchmark project will now be running on: http:{your-docker-ip}:8000
 
     Test it by navigating to that address in a browser.  It should just say "OK".
+
+    It is also running a WebSocket server at: ws://{your-docker-ip}:8000
 
     Run the benchmark's help to show the parameters::
 
@@ -37,6 +39,27 @@ How to use:
     Let's just try a quick test with the default values from the parameter list::
 
         python benchmark.py ws://localhost:80
+
+How to use with runserver:
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+    You must have a local Redis server running on localhost:6739 for this to work!  If you happen
+    to be running Docker, this can easily be done with::
+
+        docker run -d --name redis_local -p 6379:6379 redis:alpine
+
+    Just to make sure you're up to date with migrations, run::
+
+        python manage.py migrate
+
+    In one terminal window, run the server with::
+
+        python manage.py runserver
+
+    In another terminal window, run the benchmark with::
+
+        python benchmark.py ws://localhost:8000
+
 
 
 

--- a/testproject/README.rst
+++ b/testproject/README.rst
@@ -26,11 +26,11 @@ How to use with Docker:
 
         docker-compose up -d
 
-    The benchmark project will now be running on: http:{your-docker-ip}:8000
+    The benchmark project will now be running on: http:{your-docker-ip}:80
 
     Test it by navigating to that address in a browser.  It should just say "OK".
 
-    It is also running a WebSocket server at: ws://{your-docker-ip}:8000
+    It is also running a WebSocket server at: ws://{your-docker-ip}:80
 
     Run the benchmark's help to show the parameters::
 

--- a/testproject/docker-compose.yml
+++ b/testproject/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     redis:
-        image: redis
+        image: redis:alpine
     daphne:
         image: channels-test
         build: .

--- a/testproject/requirements.txt
+++ b/testproject/requirements.txt
@@ -1,0 +1,14 @@
+asgi-redis==0.13.1
+asgiref==0.13.3
+autobahn==0.14.1
+channels==0.14.2
+daphne==0.12.1
+Django==1.9.7
+docutils==0.12
+msgpack-python==0.4.7
+redis==2.10.5
+six==1.10.0
+statistics==1.0.3.5
+Twisted==16.2.0
+txaio==2.5.1
+zope.interface==4.2.0


### PR DESCRIPTION
Removed unneeded python-dev from Docker build.

Changed docker-compose.yml to use redis:alpine, it's almost an order of magnitude smaller than redis:latest.

Added instructions for setting up and running benchmark to README.rst.

Feel free to cherry-pick as I noticed you didn't incorporate my other Docker file changes in the channel-examples project though I'm not sure why...