### PR TITLE
Add community page

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -1,0 +1,10 @@
+Community Projects
+==================
+
+These projects from the community are developed on top of Channels:
+
+* Djangobot_, a bi-directional interface server for Slack.
+
+If you'd like to add your project, please submit a PR with a link and brief description.
+
+.. _Djangobot: https://github.com/djangobot/djangobot

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,3 +37,4 @@ Contents:
    reference
    faqs
    asgi
+   community


### PR DESCRIPTION
I've added a basic page to collect links to projects from the community built
atop or around Channels. As we get more links we might consider adding specific
sections (how-to's, etc.).