### PR TITLE
Test runserver

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,6 +1,6 @@
 [run]
 branch = True
-source = channels, django.http.response
+source = channels
 omit = channels/tests/*
 
 [report]

--- a/channels/log.py
+++ b/channels/log.py
@@ -1,5 +1,6 @@
 import logging
 
+handler = logging.StreamHandler()
 
 def setup_logger(name, verbosity=1):
     """
@@ -8,7 +9,6 @@ def setup_logger(name, verbosity=1):
 
     formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
 
-    handler = logging.StreamHandler()
     handler.setFormatter(formatter)
 
     # Set up main logger

--- a/channels/log.py
+++ b/channels/log.py
@@ -2,12 +2,14 @@ import logging
 
 handler = logging.StreamHandler()
 
+
 def setup_logger(name, verbosity=1):
     """
     Basic logger for runserver etc.
     """
 
-    formatter = logging.Formatter(fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
+    formatter = logging.Formatter(
+        fmt='%(asctime)s - %(levelname)s - %(module)s - %(message)s')
 
     handler.setFormatter(formatter)
 
@@ -22,7 +24,8 @@ def setup_logger(name, verbosity=1):
     for module in ["daphne.ws_protocol", "daphne.http_protocol"]:
         daphne_logger = logging.getLogger(module)
         daphne_logger.addHandler(handler)
-        daphne_logger.setLevel(logging.DEBUG if verbosity > 1 else logging.INFO)
+        daphne_logger.setLevel(
+            logging.DEBUG if verbosity > 1 else logging.INFO)
 
     logger.propagate = False
     return logger

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -2,6 +2,7 @@ import datetime
 import sys
 import threading
 
+from daphne.server import Server
 from django.conf import settings
 from django.core.management.commands.runserver import \
     Command as RunserverCommand
@@ -13,7 +14,6 @@ from channels.handler import ViewConsumer
 from channels.log import setup_logger
 from channels.staticfiles import StaticFilesConsumer
 from channels.worker import Worker
-from daphne.server import Server
 
 
 class Command(RunserverCommand):

--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -13,6 +13,7 @@ from channels.handler import ViewConsumer
 from channels.log import setup_logger
 from channels.staticfiles import StaticFilesConsumer
 from channels.worker import Worker
+from daphne.server import Server
 
 
 class Command(RunserverCommand):
@@ -72,7 +73,6 @@ class Command(RunserverCommand):
         # actually a subthread under the autoreloader.
         self.logger.debug("Daphne running, listening on %s:%s", self.addr, self.port)
         try:
-            from daphne.server import Server
             Server(
                 channel_layer=self.channel_layer,
                 host=self.addr,

--- a/channels/management/commands/runworker.py
+++ b/channels/management/commands/runworker.py
@@ -1,5 +1,4 @@
 from __future__ import unicode_literals
-
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 

--- a/channels/management/commands/runworker.py
+++ b/channels/management/commands/runworker.py
@@ -1,11 +1,12 @@
 from __future__ import unicode_literals
+
 from django.conf import settings
 from django.core.management import BaseCommand, CommandError
 
 from channels import DEFAULT_CHANNEL_LAYER, channel_layers
 from channels.log import setup_logger
-from channels.worker import Worker
 from channels.staticfiles import StaticFilesConsumer
+from channels.worker import Worker
 
 
 class Command(BaseCommand):

--- a/channels/tests/__init__.py
+++ b/channels/tests/__init__.py
@@ -1,2 +1,3 @@
 from .base import ChannelTestCase, Client, apply_routes  # NOQA isort:skip
 from .http import HttpClient  # NOQA isort:skip
+

--- a/channels/tests/__init__.py
+++ b/channels/tests/__init__.py
@@ -1,3 +1,2 @@
 from .base import ChannelTestCase, Client, apply_routes  # NOQA isort:skip
 from .http import HttpClient  # NOQA isort:skip
-

--- a/channels/tests/settings.py
+++ b/channels/tests/settings.py
@@ -1,5 +1,13 @@
 SECRET_KEY = 'cat'
 
+INSTALLED_APPS = (
+'django.contrib.auth',
+'django.contrib.contenttypes',
+'django.contrib.sessions',
+'django.contrib.admin',
+'channels',
+)
+
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -11,6 +19,10 @@ CHANNEL_LAYERS = {
         'BACKEND': 'asgiref.inmemory.ChannelLayer',
         'ROUTING': [],
     },
+    'fake_channel': {
+        'BACKEND': 'channels.tests.test_management.FakeChannelLayer',
+        'ROUTING': [],
+    }
 }
 
 MIDDLEWARE_CLASSES = []

--- a/channels/tests/settings.py
+++ b/channels/tests/settings.py
@@ -1,11 +1,11 @@
 SECRET_KEY = 'cat'
 
 INSTALLED_APPS = (
-'django.contrib.auth',
-'django.contrib.contenttypes',
-'django.contrib.sessions',
-'django.contrib.admin',
-'channels',
+    'django.contrib.auth',
+    'django.contrib.contenttypes',
+    'django.contrib.sessions',
+    'django.contrib.admin',
+    'channels',
 )
 
 DATABASES = {

--- a/channels/tests/test_management.py
+++ b/channels/tests/test_management.py
@@ -43,8 +43,8 @@ class RunWorkerTests(TestCase):
             mock_worker.assert_called_with(
                 only_channels=None, exclude_channels=None, callback=None, channel_layer=mock.ANY)
 
-            cl = mock_worker.call_args[1]['channel_layer']
-            static_consumer = cl.router.root.routing[0].consumer
+            channel_layer = mock_worker.call_args[1]['channel_layer']
+            static_consumer = channel_layer.router.root.routing[0].consumer
             self.assertIsInstance(static_consumer, StaticFilesConsumer)
 
     def test_runworker(self, mock_worker):
@@ -55,7 +55,7 @@ class RunWorkerTests(TestCase):
                                        channel_layer=mock.ANY,
                                        exclude_channels=None)
 
-    def test_runworker_verbose(self, mocked_worker, *args):
+    def test_runworker_verbose(self, mocked_worker):
         # Use 'fake_channel' that bypasses the 'inmemory' check
         call_command('runworker', '--layer',
                      'fake_channel', '--verbosity', '2')
@@ -79,7 +79,7 @@ class RunServerTests(TestCase):
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
     @mock.patch('channels.management.commands.runserver.Server')
     @mock.patch('channels.management.commands.runworker.Worker')
-    def test_runserver_basic(self, mocked_worker, mocked_server, *args):
+    def test_runserver_basic(self, mocked_worker, mocked_server, mock_stdout):
         # Django's autoreload util uses threads and this is not needed
         # in the test envirionment.
         # See:
@@ -91,7 +91,7 @@ class RunServerTests(TestCase):
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
     @mock.patch('channels.management.commands.runserver.Server')
     @mock.patch('channels.management.commands.runworker.Worker')
-    def test_runserver_debug(self, mocked_worker, mocked_server, *args):
+    def test_runserver_debug(self, mocked_worker, mocked_server, mock_stdout):
         """
         Test that the server runs with `DEBUG=True`.
         """
@@ -111,7 +111,7 @@ class RunServerTests(TestCase):
     @mock.patch('channels.management.commands.runserver.sys.stdout', new_callable=StringIO)
     @mock.patch('channels.management.commands.runserver.Server')
     @mock.patch('channels.management.commands.runworker.Worker')
-    def test_runserver_noworker(self, mocked_worker, mocked_server, *args):
+    def test_runserver_noworker(self, mocked_worker, mocked_server, mock_stdout):
         '''
         Test that the Worker is not called when using the `--noworker` parameter.
         '''

--- a/channels/tests/test_management.py
+++ b/channels/tests/test_management.py
@@ -1,0 +1,133 @@
+from __future__ import unicode_literals
+import logging
+from six import StringIO
+from functools import partial
+from django.core.management import CommandError
+from django.conf import settings
+from django.core.management import call_command
+from django.test import TestCase, mock
+
+from asgiref.inmemory import ChannelLayer
+from channels.management.commands import runserver
+import logging
+
+class FakeChannelLayer(ChannelLayer):
+    '''
+    Dummy class to bypass the 'inmemory' string check.
+    '''
+    pass
+
+
+class RunWorkerTests(TestCase):
+
+    def setUp(self):
+        import channels.log
+        self.stream = StringIO()
+        channels.log.handler = logging.StreamHandler(self.stream)
+
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_runworker_no_local_only(self, mock_stdout, mock_stderr):
+        with self.assertRaises(CommandError):
+            call_command('runworker')
+
+    @mock.patch('channels.management.commands.runworker.Worker')
+    def test_debug(self, mocked_worker, *args, **kwargs):
+        with self.settings(DEBUG=True, STATIC_URL='/static/'):
+            call_command('runworker', '--layer', 'fake_channel')
+            mocked_worker.assert_called_with(only_channels=None, exclude_channels=None, callback=None, channel_layer=mock.ANY)
+
+    @mock.patch('channels.management.commands.runworker.Worker')
+    def test_runworker(self, mocked_worker):
+        call_command('runworker', '--layer', 'fake_channel')
+        mocked_worker.assert_called_with(callback=None,
+                only_channels=None,
+                channel_layer=mock.ANY,
+                exclude_channels=None)
+
+    @mock.patch('channels.management.commands.runworker.Worker')
+    def test_runworker_verbose(self, mocked_worker):
+        call_command('runworker', '--layer',
+                     'fake_channel', '--verbosity', '2')
+        # Increasing verbosity adds the logger callback
+        mocked_worker.assert_called_with(callback=mock.ANY,
+                only_channels=None,
+                channel_layer=mock.ANY,
+                exclude_channels=None)
+
+
+class RunServerTests(TestCase):
+
+    def setUp(self):
+        import channels.log
+        self.stream = StringIO()
+        channels.log.handler = logging.StreamHandler(self.stream)
+
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('channels.management.commands.runserver.Server')
+    @mock.patch('channels.management.commands.runworker.Worker')
+    def test_runserver_basic(self, mocked_worker, mocked_server, mock_stdout, mock_stderr):
+        call_command('runserver', '--noreload')
+        mocked_server.assert_called_with(port=8000, signal_handlers=True, http_timeout=60,
+                                         host='127.0.0.1', action_logger=mock.ANY, channel_layer=mock.ANY)
+
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('channels.management.commands.runserver.Server')
+    @mock.patch('channels.management.commands.runworker.Worker')
+    def test_runserver_nostatic(self, mocked_worker, mocked_server, mock_stdout, mock_stderr):
+        with self.settings(DEBUG=True, STATIC_URL='/static/'):
+            call_command('runserver', '--noreload')
+            mocked_server.assert_called_with(port=8000, signal_handlers=True, http_timeout=60,
+                                             host='127.0.0.1', action_logger=mock.ANY, channel_layer=mock.ANY)
+
+            call_command('runserver', '--noreload', 'localhost:8001')
+            mocked_server.assert_called_with(port=8001, signal_handlers=True, http_timeout=60,
+                                             host='localhost', action_logger=mock.ANY, channel_layer=mock.ANY)
+
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    @mock.patch('channels.management.commands.runserver.Server')
+    def test_runserver_noworker(self, mocked_server, mock_stdout, mock_stderr):
+        '''
+        No need to Mock the Worker because it should not be used.
+        '''
+        call_command('runserver', '--noreload', '--noworker')
+
+    @mock.patch('sys.stderr', new_callable=StringIO)
+    @mock.patch('sys.stdout', new_callable=StringIO)
+    def test_log_action(self, mock_stdout, mock_stderr):
+        cmd = runserver.Command()
+        test_actions = [
+            (100, 'http', 'complete',
+             'HTTP GET /a-path/ 100 [0.12, a-client]'),
+            (200, 'http', 'complete',
+             'HTTP GET /a-path/ 200 [0.12, a-client]'),
+            (300, 'http', 'complete',
+             'HTTP GET /a-path/ 300 [0.12, a-client]'),
+            (304, 'http', 'complete',
+             'HTTP GET /a-path/ 304 [0.12, a-client]'),
+            (400, 'http', 'complete',
+             'HTTP GET /a-path/ 400 [0.12, a-client]'),
+            (404, 'http', 'complete',
+             'HTTP GET /a-path/ 404 [0.12, a-client]'),
+            (500, 'http', 'complete',
+             'HTTP GET /a-path/ 500 [0.12, a-client]'),
+            (None, 'websocket', 'connected',
+             'WebSocket CONNECT /a-path/ [a-client]'),
+            (None, 'websocket', 'disconnected',
+             'WebSocket DISCONNECT /a-path/ [a-client]'),
+            (None, 'websocket', 'something', ''),  # This shouldn't happen
+        ]
+
+        for status_code, protocol, action, output in test_actions:
+            details = {'status': status_code,
+                       'method': 'GET',
+                       'path': '/a-path/',
+                       'time_taken': 0.12345,
+                       'client': 'a-client'}
+            cmd.log_action(protocol, action, details)
+            self.assertIn(output, mock_stderr.getvalue())
+            # Clear previous output
+            mock_stderr.truncate(0)

--- a/channels/tests/test_management.py
+++ b/channels/tests/test_management.py
@@ -1,15 +1,14 @@
 from __future__ import unicode_literals
+
 import logging
-from six import StringIO
-from functools import partial
-from django.core.management import CommandError
-from django.conf import settings
-from django.core.management import call_command
-from django.test import TestCase, mock
 
 from asgiref.inmemory import ChannelLayer
+from django.core.management import CommandError, call_command
+from django.test import TestCase, mock
+from six import StringIO
+
 from channels.management.commands import runserver
-import logging
+
 
 class FakeChannelLayer(ChannelLayer):
     '''
@@ -35,15 +34,16 @@ class RunWorkerTests(TestCase):
     def test_debug(self, mocked_worker, *args, **kwargs):
         with self.settings(DEBUG=True, STATIC_URL='/static/'):
             call_command('runworker', '--layer', 'fake_channel')
-            mocked_worker.assert_called_with(only_channels=None, exclude_channels=None, callback=None, channel_layer=mock.ANY)
+            mocked_worker.assert_called_with(
+                only_channels=None, exclude_channels=None, callback=None, channel_layer=mock.ANY)
 
     @mock.patch('channels.management.commands.runworker.Worker')
     def test_runworker(self, mocked_worker):
         call_command('runworker', '--layer', 'fake_channel')
         mocked_worker.assert_called_with(callback=None,
-                only_channels=None,
-                channel_layer=mock.ANY,
-                exclude_channels=None)
+                                         only_channels=None,
+                                         channel_layer=mock.ANY,
+                                         exclude_channels=None)
 
     @mock.patch('channels.management.commands.runworker.Worker')
     def test_runworker_verbose(self, mocked_worker):
@@ -51,9 +51,9 @@ class RunWorkerTests(TestCase):
                      'fake_channel', '--verbosity', '2')
         # Increasing verbosity adds the logger callback
         mocked_worker.assert_called_with(callback=mock.ANY,
-                only_channels=None,
-                channel_layer=mock.ANY,
-                exclude_channels=None)
+                                         only_channels=None,
+                                         channel_layer=mock.ANY,
+                                         exclude_channels=None)
 
 
 class RunServerTests(TestCase):

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ setenv =
 deps =
     autobahn
     coverage
+    daphne
     asgiref>=0.9
     six
     redis==2.10.5


### PR DESCRIPTION
This PR brings run the `runserver` and `runworker` management commands up to 91% and 95% respectively.  I tried to change as little in the code as possible but to capture the logging, I had to move the `handler = logging.StreamHandler()` line out of the function into the module so that it could be overridden. Without that I couldn't find a place to mock the logging.