### PR TITLE
#221: generic connect transfer user if needed

### DIFF
--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
 from channels.sessions import channel_session
-from channels.auth import channel_session_user
+from channels.auth import channel_session_user, channel_session_user_from_http
 
 
 class BaseConsumer(object):
@@ -43,6 +43,8 @@ class BaseConsumer(object):
         """
         handler = getattr(self, self.method_mapping[message.channel.name])
         if self.channel_session_user:
+            if message.channel.name == 'websocket.connect':
+                return channel_session_user_from_http(handler)
             return channel_session_user(handler)
         elif self.channel_session:
             return channel_session(handler)


### PR DESCRIPTION
Not so flexable, but keep the most common usage work.
Would you want to let user config each method_mapping, something like:
```
method_mapping = {
    "websocket.connect": "raw_connect",
    "websocket.receive": "raw_receive",
    "websocket.disconnect": "raw_disconnect",
}

channel_session_user = {
    "websocket.receive": True
    "websocket.disconnect": True,
}

channel_session_user_from_http = {
    "websocket.connect": True,
}
```
so user could write/config their own class-based consumers from scratch