### PR TITLE
Register Bindings as soon as they are declared

### DIFF
--- a/channels/apps.py
+++ b/channels/apps.py
@@ -1,8 +1,6 @@
 from django.apps import AppConfig
 from django.core.exceptions import ImproperlyConfigured
 
-from .binding.base import BindingMetaclass
-
 
 class ChannelsConfig(AppConfig):
 

--- a/channels/apps.py
+++ b/channels/apps.py
@@ -20,5 +20,3 @@ class ChannelsConfig(AppConfig):
         # Do django monkeypatches
         from .hacks import monkeypatch_django
         monkeypatch_django()
-        # Instantiate bindings
-        BindingMetaclass.register_all()

--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -13,18 +13,11 @@ class BindingMetaclass(type):
     Metaclass that tracks instantiations of its type.
     """
 
-    binding_classes = []
-
     def __new__(cls, name, bases, body):
         klass = type.__new__(cls, name, bases, body)
         if bases != (object, ):
-            cls.binding_classes.append(klass)
+            klass.register()
         return klass
-
-    @classmethod
-    def register_all(cls):
-        for binding_class in cls.binding_classes:
-            binding_class.register()
 
 
 @six.add_metaclass(BindingMetaclass)
@@ -70,8 +63,9 @@ class Binding(object):
             cls.model._meta.object_name.lower(),
         )
         # Connect signals
-        post_save.connect(cls.save_receiver, sender=cls.model)
-        post_delete.connect(cls.delete_receiver, sender=cls.model)
+        uid = "Binding %s.%s" % (cls.__module__, cls.__name__)
+        post_save.connect(cls.save_receiver, sender=cls.model, dispatch_uid=uid)
+        post_delete.connect(cls.delete_receiver, sender=cls.model, dispatch_uid=uid)
 
     # Outbound binding
 


### PR DESCRIPTION
With the old approach - keeping a list of classes and registering them in the ``ready``-method in ``apps.py`` - I had the problem that ready got called before my ``consumers.py``, where my bindings are, was loaded. So ``register_all`` ran on an empty list and my bindings where not registered.  I also added a uid to the signal-connections to prevent duplicate messages.