### PR TITLE
add a modelname to the payload dict

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -36,6 +36,7 @@ class WebsocketBinding(Binding):
     def serialize(self, instance, action):
         payload = {
             "action": action,
+            "model": instance.__class__.__name__
             "pk": instance.pk,
             "data": self.serialize_data(instance),
         }


### PR DESCRIPTION
Would be sometimes really useful, especially if you use one Multiplexer with several Bindings