### PR TITLE
Register Bindings if they are declared after ready has run

### DIFF
--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -12,7 +12,7 @@ class BindingMetaclass(type):
     """
     Metaclass that tracks instantiations of its type.
     """
-    
+
     register_immediately = False
     binding_classes = []
 

--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -12,19 +12,23 @@ class BindingMetaclass(type):
     """
     Metaclass that tracks instantiations of its type.
     """
-
+    
+    register_immediately = False
     binding_classes = []
 
     def __new__(cls, name, bases, body):
         klass = type.__new__(cls, name, bases, body)
         if bases != (object, ):
             cls.binding_classes.append(klass)
+            if cls.register_immediately:
+                cls.register()
         return klass
 
     @classmethod
     def register_all(cls):
         for binding_class in cls.binding_classes:
             binding_class.register()
+        cls.register_immediately = True
 
 
 @six.add_metaclass(BindingMetaclass)


### PR DESCRIPTION
If the declaration of a binding happens after the ``ready``-method of channels has run, the binding was not registered. With this it will be registered at declaration. This also ensures that no registration happens before the ``ready``-method runs.