### PR TITLE
move encoding from serialize to trigger_outbound

### DIFF
--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -97,9 +97,13 @@ class Binding(object):
         self = cls()
         self.instance = instance
         # Check to see if we're covered
-        for group_name in self.group_names(instance, action):
-            group = Group(group_name)
-            group.send(self.serialize(instance, action))
+        assert self.stream is not None
+        payload = self.serialize(instance, action)
+        if payload != {}:
+            message = WebsocketDemultiplexer.encode(self.stream, payload)
+            for group_name in self.group_names(instance, action):
+                group = Group(group_name)
+                group.send(message)
 
     def group_names(self, instance, action):
         """

--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -88,7 +88,7 @@ class Binding(object):
         Entry point for triggering the binding from save signals.
         """
         cls.trigger_outbound(instance, "delete")
-    
+
     @classmethod
     def encode(cls, stream, payload):
         """

--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -88,6 +88,13 @@ class Binding(object):
         Entry point for triggering the binding from save signals.
         """
         cls.trigger_outbound(instance, "delete")
+    
+    @classmethod
+    def encode(cls, stream, payload):
+        """
+        Encodes stream + payload for outbound sending.
+        """
+        raise NotImplementedError()
 
     @classmethod
     def trigger_outbound(cls, instance, action):
@@ -100,7 +107,7 @@ class Binding(object):
         payload = self.serialize(instance, action)
         if payload != {}:
             assert self.stream is not None
-            message = WebsocketDemultiplexer.encode(self.stream, payload)
+            message = cls.encode(self.stream, payload)
             for group_name in self.group_names(instance, action):
                 group = Group(group_name)
                 group.send(message)
@@ -115,9 +122,7 @@ class Binding(object):
     def serialize(self, instance, action):
         """
         Should return a serialized version of the instance to send over the
-        wire (return value must be a dict suitable for sending over a channel -
-        e.g., to send JSON as a WebSocket text frame, you must return
-        {"text": json.dumps(instance_serialized_as_dict)}
+        wire (e.g. {"pk": 12, "value": 42, "string": "some string"})
         """
         raise NotImplementedError()
 

--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -97,9 +97,9 @@ class Binding(object):
         self = cls()
         self.instance = instance
         # Check to see if we're covered
-        assert self.stream is not None
         payload = self.serialize(instance, action)
         if payload != {}:
+            assert self.stream is not None
             message = WebsocketDemultiplexer.encode(self.stream, payload)
             for group_name in self.group_names(instance, action):
                 group = Group(group_name)

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -40,9 +40,7 @@ class WebsocketBinding(Binding):
             "data": self.serialize_data(instance),
             "model": self.model_label,
         }
-        # Encode for the stream
-        assert self.stream is not None
-        return WebsocketDemultiplexer.encode(self.stream, payload)
+        return payload
 
     def serialize_data(self, instance):
         """

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -35,7 +35,6 @@ class WebsocketBinding(Binding):
     @classmethod
     def encode(cls, stream, payload):
         return WebsocketDemultiplexer.encode(stream, payload)
-    
 
     def serialize(self, instance, action):
         payload = {

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -32,6 +32,10 @@ class WebsocketBinding(Binding):
     stream = None
 
     # Outbound
+    @classmethod
+    def encode(cls, stream, payload):
+        return WebsocketDemultiplexer.encode(stream, payload)
+    
 
     def serialize(self, instance, action):
         payload = {


### PR DESCRIPTION
Allows to return a empty dict in serialize to prevent sending. Useful if you want to only send the changed fields, also makes it easier to provide your own serialize-method. 
Example for sending only changed fields:
```` python
def serialize(self, instance, action):
    new_data = self.serialize_data(instance)
    cache_key = "{0}{1}".format(instance.__class__, instance.pk)
    old_data = cache.get(cache_key, {})
    cache.set(cache_key, new_data, 10)
    diff = {}
    for key in new_data.keys():
        try:
            if new_data[key] != old_data[key]:
                diff[key] = new_data[key]
        except KeyError:
            diff[key] = new_data[key]
    if diff == {}:
        return {}
    else:
        payload = {
            "action": action,
            "pk": instance.pk,
            "model": instance.__class__.__name__,
            "data": diff,
        }
        return payload
````