### PR TITLE
Security fix - every field of a model is send - even password

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -30,10 +30,10 @@ class WebsocketBinding(Binding):
     # Stream multiplexing name
 
     stream = None
-    
+
     # only model fields that are listed in fields should be send by default
     # if you want to really send all fields, use fields = ['__all__']
-    
+
     fields = []
 
     # Outbound

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -30,6 +30,11 @@ class WebsocketBinding(Binding):
     # Stream multiplexing name
 
     stream = None
+    
+    # only model fields that are listed in fields should be send by default
+    # if you want to really send all fields, use fields = ['__all__']
+    
+    fields = []
 
     # Outbound
     @classmethod
@@ -49,7 +54,9 @@ class WebsocketBinding(Binding):
         """
         Serializes model data into JSON-compatible types.
         """
-        data = serializers.serialize('json', [instance])
+        if self.fields == ['__all__']:
+            self.fields = None
+        data = serializers.serialize('json', [instance], fields=self.fields)
         return json.loads(data)[0]['fields']
 
     # Inbound

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -56,6 +56,8 @@ class WebsocketBinding(Binding):
         """
         if self.fields == ['__all__']:
             self.fields = None
+        elif not self.fields:
+            raise ValueError("You must set the fields attribute on Binding %r!" % self.__class__)
         data = serializers.serialize('json', [instance], fields=self.fields)
         return json.loads(data)[0]['fields']
 


### PR DESCRIPTION
Atm WebsocketBinding sends every field of a model, even the password of a user. Users of the class should have to think about which fields they want to send to the user. Also added a more intuitive option for sending all fields.