### PR TITLE
as_route method for class based consumers

### DIFF
--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -1,6 +1,6 @@
 from __future__ import unicode_literals
-from channels.sessions import channel_session
-from channels.auth import channel_session_user
+from ..sessions import channel_session
+from ..auth import channel_session_user
 
 
 class BaseConsumer(object):

--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -39,16 +39,14 @@ class BaseConsumer(object):
         return set(cls.method_mapping.keys())
 
     @classmethod
-    def as_route(cls, **kwargs):
+    def as_route(cls, filters, **kwargs):
         """
-        Return the route_class that can directly using at a routes
+        Shortcut function to create route with filters to direct to a class-based consumer with given kwargs
         """
         _cls = cls
-        _kwargs = dict(kwargs)
-        _dict = {key: _kwargs.pop(key) for key in kwargs.keys() if key in dir(_cls)}
-        if _dict:
-            _cls = type(cls.__name__, (cls,), _dict)
-        return route_class(_cls, **_kwargs)
+        if kwargs:
+            _cls = type(cls.__name__, (cls,), kwargs)
+        return route_class(_cls, **filters)
 
     def get_handler(self, message, **kwargs):
         """

--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -43,13 +43,12 @@ class BaseConsumer(object):
         """
         Return the route_class that can directly using at a routes
         """
-        _dir = dir(cls)
-        _dict = dict(cls.__dict__)
+        _cls = cls
         _kwargs = dict(kwargs)
-        for key in kwargs.keys():
-            if key in _dir:
-                _dict[key] = _kwargs.pop(key)
-        return route_class(type(cls.__name__, (cls,), _dict), **_kwargs)
+        _dict = {key: _kwargs.pop(key) for key in kwargs.keys() if key in dir(_cls)}
+        if _dict:
+            _cls = type(cls.__name__, (cls,), _dict)
+        return route_class(_cls, **_kwargs)
 
     def get_handler(self, message, **kwargs):
         """

--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -39,14 +39,16 @@ class BaseConsumer(object):
         return set(cls.method_mapping.keys())
 
     @classmethod
-    def as_route(cls, filters, **kwargs):
+    def as_route(cls, attrs=None, **kwargs):
         """
-        Shortcut function to create route with filters to direct to a class-based consumer with given kwargs
+        Shortcut function to create route with filters (kwargs)
+        to direct to a class-based consumer with given class attributes (attrs)
         """
         _cls = cls
-        if kwargs:
-            _cls = type(cls.__name__, (cls,), kwargs)
-        return route_class(_cls, **filters)
+        if attrs:
+            assert isinstance(attrs, dict), 'Attri'
+            _cls = type(cls.__name__, (cls,), attrs)
+        return route_class(_cls, **kwargs)
 
     def get_handler(self, message, **kwargs):
         """

--- a/channels/generic/base.py
+++ b/channels/generic/base.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+from ..routing import route_class
 from ..sessions import channel_session
 from ..auth import channel_session_user
 
@@ -36,6 +37,19 @@ class BaseConsumer(object):
         derived from the method_mapping class attribute.
         """
         return set(cls.method_mapping.keys())
+
+    @classmethod
+    def as_route(cls, **kwargs):
+        """
+        Return the route_class that can directly using at a routes
+        """
+        _dir = dir(cls)
+        _dict = dict(cls.__dict__)
+        _kwargs = dict(kwargs)
+        for key in kwargs.keys():
+            if key in _dir:
+                _dict[key] = _kwargs.pop(key)
+        return route_class(type(cls.__name__, (cls,), _dict), **_kwargs)
 
     def get_handler(self, message, **kwargs):
         """

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -113,7 +113,6 @@ class GenericTests(ChannelTestCase):
             client.send_and_consume('websocket.connect', {'path': '/path/2', 'order': 'next'})
             self.assertEqual(client.receive(), {'text': 'next'})
 
-
     def test_as_route_method(self):
         class WebsocketConsumer(BaseConsumer):
             trigger = 'new'

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -92,8 +92,8 @@ class GenericTests(ChannelTestCase):
                 self.send(text=message.get('order'))
 
         routes = [
-            WebsocketConsumer.as_route(slight_ordering=True, filters={'path': '^/path$'}),
-            WebsocketConsumer.as_route(filters={'path': '^/path/2$'}),
+            WebsocketConsumer.as_route(attrs={'slight_ordering': True}, path='^/path$'),
+            WebsocketConsumer.as_route(path='^/path/2$'),
         ]
 
         self.assertIsNot(routes[0].consumer, WebsocketConsumer)
@@ -123,9 +123,8 @@ class GenericTests(ChannelTestCase):
         method_mapping = {'mychannel': 'test'}
 
         with apply_routes([WebsocketConsumer.as_route(
-                method_mapping=method_mapping,
-                trigger='from_as_route',
-                filters={'name': 'filter'})]):
+                {'method_mapping': method_mapping, 'trigger': 'from_as_route'},
+                name='filter')]):
             client = Client()
 
             client.send_and_consume('mychannel', {'name': 'filter'})

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -83,3 +83,39 @@ class GenericTests(ChannelTestCase):
             client.consume('websocket.connect')
             self.assertEqual(client.consume('websocket.connect').order, 0)
             self.assertEqual(client.consume('websocket.connect').order, 1)
+
+    def test_simple_as_route_method(self):
+
+        class WebsocketConsumer(websockets.WebsocketConsumer):
+
+            def connect(self, message, **kwargs):
+                self.send(text=message.get('order'))
+
+        with apply_routes([WebsocketConsumer.as_route(slight_ordering=True, path='/path')]):
+            client = Client()
+
+            client.send('websocket.connect', {'path': '/path', 'order': 1})
+            client.send('websocket.connect', {'path': '/path', 'order': 0})
+            client.consume('websocket.connect')
+            client.consume('websocket.connect')
+            client.consume('websocket.connect')
+            self.assertEqual(client.receive(), {'text': 0})
+            self.assertEqual(client.receive(), {'text': 1})
+
+    def test_as_route_method(self):
+        class WebsocketConsumer(BaseConsumer):
+            trigger = 'new'
+
+            def test(self, message, **kwargs):
+                self.message.reply_channel.send({'trigger': self.trigger})
+
+        method_mapping = {'mychannel': 'test'}
+
+        with apply_routes([WebsocketConsumer.as_route(
+                method_mapping=method_mapping,
+                trigger='from_as_route',
+                name='filter')]):
+            client = Client()
+
+            client.send_and_consume('mychannel', {'name': 'filter'})
+            self.assertEqual(client.receive(), {'trigger': 'from_as_route'})

--- a/channels/tests/test_generic.py
+++ b/channels/tests/test_generic.py
@@ -92,8 +92,8 @@ class GenericTests(ChannelTestCase):
                 self.send(text=message.get('order'))
 
         routes = [
-            WebsocketConsumer.as_route(slight_ordering=True, path='^/path$'),
-            WebsocketConsumer.as_route(path='^/path/2$'),
+            WebsocketConsumer.as_route(slight_ordering=True, filters={'path': '^/path$'}),
+            WebsocketConsumer.as_route(filters={'path': '^/path/2$'}),
         ]
 
         self.assertIsNot(routes[0].consumer, WebsocketConsumer)
@@ -125,7 +125,7 @@ class GenericTests(ChannelTestCase):
         with apply_routes([WebsocketConsumer.as_route(
                 method_mapping=method_mapping,
                 trigger='from_as_route',
-                name='filter')]):
+                filters={'name': 'filter'})]):
             client = Client()
 
             client.send_and_consume('mychannel', {'name': 'filter'})

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps =
     six
     redis==2.10.5
     py27: mock
-    flake8: flake8
+    flake8: flake8>=2.0,<3.0
     isort: isort
     django-18: Django>=1.8,<1.9
     django-19: Django>=1.9,<1.10


### PR DESCRIPTION
Hello @andrewgodwin 

It is proof of concept. 
I hope that somebody creates a really generic Consumers, so at this way it will be real nice to have method that gives more fluent way to use CB consumers.
Old way:
```python 
# consumers.py
from mygeneric import ModelBaseConsumers
from .models import User

class UserConsumers(ModelBaseConsumers):
    model = User
    fields = ['username', 'group']

#routes
from channels import route_class
from .consumers import UserConsumers, ....

routes = [
   route_class(UserConsumers, path='/users/'),
   ...
]
```

New way:
```python
from mygeneric import ModelBaseConsumers
from .models import User, Message

routes = [
    ModelBaseConsumers.as_route(model=User, fields=['username', 'group'], path='/users'),
    ModelBaseConsumers.as_route(model=Message, fields=['user', 'text'], path='/messags'),
]
```

What do you think about this?