### PR TITLE
Add beatserver to community projects

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -5,8 +5,10 @@ These projects from the community are developed on top of Channels:
 
 * Djangobot_, a bi-directional interface server for Slack.
 * knocker_, a generic desktop-notification system.
+* Beatserver_, a periodic task scheduler for django channels
 
 If you'd like to add your project, please submit a PR with a link and brief description.
 
 .. _Djangobot: https://github.com/djangobot/djangobot
 .. _knocker: https://github.com/nephila/django-knocker
+.. _Beatserver: https://github.com/rajasimon/beatserver


### PR DESCRIPTION
Proposing to add beatserver to community projects. Using this to create schedule task easy. 