### PR TITLE
Fix member serialization in WebsocketBindingWithMembers

### DIFF
--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -149,7 +149,9 @@ class WebsocketBindingWithMembers(WebsocketBinding):
         data = super(WebsocketBindingWithMembers, self).serialize_data(instance)
         member_data = {}
         for m in self.send_members:
-            member = getattr(instance, m)
+            member = instance
+            for s in m.split('.'):
+                member = getattr(member, s)
             if callable(member):
                 member_data[m] = member()
             else:

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -147,10 +147,14 @@ class WebsocketBindingWithMembers(WebsocketBinding):
 
     def serialize_data(self, instance):
         data = super(WebsocketBindingWithMembers, self).serialize_data(instance)
+        member_data = {}
         for m in self.send_members:
             member = getattr(instance, m)
             if callable(member):
-                data[m] = self.encoder.encode(member())
+                member_data[m] = member()
             else:
-                data[m] = self.encoder.encode(member)
+                member_data[m] = member
+        member_data = json.loads(self.encoder.encode(member_data))
+        # the update never overwrites any value from data, because an object can't have two attributes with the same name
+        data.update(member_data)    
         return data

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -155,6 +155,7 @@ class WebsocketBindingWithMembers(WebsocketBinding):
             else:
                 member_data[m] = member
         member_data = json.loads(self.encoder.encode(member_data))
-        # the update never overwrites any value from data, because an object can't have two attributes with the same name
-        data.update(member_data)    
+        # the update never overwrites any value from data,
+        # because an object can't have two attributes with the same name
+        data.update(member_data)
         return data

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -153,9 +153,9 @@ class WebsocketBindingWithMembers(WebsocketBinding):
             for s in m.split('.'):
                 member = getattr(member, s)
             if callable(member):
-                member_data[m] = member()
+                member_data[m.replace(".", "__")] = member()
             else:
-                member_data[m] = member
+                member_data[m.replace(".", "__")] = member
         member_data = json.loads(self.encoder.encode(member_data))
         # the update never overwrites any value from data,
         # because an object can't have two attributes with the same name

--- a/channels/binding/websockets.py
+++ b/channels/binding/websockets.py
@@ -153,9 +153,9 @@ class WebsocketBindingWithMembers(WebsocketBinding):
             for s in m.split('.'):
                 member = getattr(member, s)
             if callable(member):
-                member_data[m.replace(".", "__")] = member()
+                member_data[m.replace('.', '__')] = member()
             else:
-                member_data[m.replace(".", "__")] = member
+                member_data[m.replace('.', '__')] = member
         member_data = json.loads(self.encoder.encode(member_data))
         # the update never overwrites any value from data,
         # because an object can't have two attributes with the same name


### PR DESCRIPTION
Small bug fix for the serialization of members in WebsocketBindingWithMembers. Forgot to load the json back into a dict after serialization. Also encode is now just called once. 
I also added the ability to use the 'dot'-notation in ``send_members``. Now one can use:
````python
class BookBinding(WebsocketBindingWithMembers):
    model = Book
    fields = ['title']
    send_members = ['author.name']
````
and would get a ``{'author__name': 'John Doe'}`` in the data-dictionary of the payload.