### PR TITLE
Add setting to define the count of worker started with runserver

### DIFF
--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -65,7 +65,7 @@ class Command(RunserverCommand):
 
         # Launch workers as subthreads
         if options.get("run_worker", True):
-            for _ in range(4):
+            for _ in range(getattr(settings, 'CHANNEL_DEVELOPMENT_WORKERS', 4)):
                 worker = WorkerThread(self.channel_layer, self.logger)
                 worker.daemon = True
                 worker.start()


### PR DESCRIPTION
This PR adds a new setting ```CHANNEL_DEVELOPMENT_WORKERS``` which makes it possible to define the count of workers started with the runserver command.

The reason for my request is, that I have problems with the runserver command and sqlite. I can't get rid of “Database is locked” errors. I tried to set a higher timeout value like suggested at https://docs.djangoproject.com/en/1.9/ref/databases/#database-is-locked-errors but for reasons I don't understand, it does not work. Therefore I would like to start the development server only with one thread.

Another solution which does not require the new settings would be this patch: https://github.com/andrewgodwin/channels/compare/master...ostcar:change_runserver This would make it easy to override the runserver command. But I think this PR will help in other projects, too.

If you don't want to change your code, then I have to create my own runserver command which looks exactly like yours but with only one line changed.