### PR TITLE
Start only one worker with the nothreading option.

### DIFF
--- a/channels/management/commands/runserver.py
+++ b/channels/management/commands/runserver.py
@@ -65,7 +65,8 @@ class Command(RunserverCommand):
 
         # Launch workers as subthreads
         if options.get("run_worker", True):
-            for _ in range(4):
+            worker_count = 4 if options.get("use_threading", True) else 1
+            for _ in range(worker_count):
                 worker = WorkerThread(self.channel_layer, self.logger)
                 worker.daemon = True
                 worker.start()


### PR DESCRIPTION
Reuse the nothreading option of the runserver command to only start one
worker.