### PR TITLE
Definition of groups at the class

### DIFF
--- a/channels/generic/websockets.py
+++ b/channels/generic/websockets.py
@@ -27,6 +27,8 @@ class WebsocketConsumer(BaseConsumer):
     slight_ordering = False
     strict_ordering = False
 
+    groups = None
+
     def get_handler(self, message, **kwargs):
         """
         Pulls out the path onto an instance variable, and optionally
@@ -54,7 +56,7 @@ class WebsocketConsumer(BaseConsumer):
         Group(s) to make people join when they connect and leave when they
         disconnect. Make sure to return a list/tuple, not a string!
         """
-        return []
+        return self.groups or []
 
     def raw_connect(self, message, **kwargs):
         """


### PR DESCRIPTION
With this changes and `as_route` method, creation 'consumers' for Group connection becomes easier:
```python
routes = [
    WebsocketConsumer.as_route(attrs={'groups': ['my_group', ]}, path='^/connect/my/$'),
]
```