### PR TITLE
Add django-channels-panel to the list of community projects

### DIFF
--- a/docs/community.rst
+++ b/docs/community.rst
@@ -7,6 +7,7 @@ These projects from the community are developed on top of Channels:
 * knocker_, a generic desktop-notification system.
 * Beatserver_, a periodic task scheduler for django channels.
 * cq_, a simple distributed task system.
+* Debugpannel_, a django Debug Toolbar panel for channels.
 
 If you'd like to add your project, please submit a PR with a link and brief description.
 
@@ -14,3 +15,4 @@ If you'd like to add your project, please submit a PR with a link and brief desc
 .. _knocker: https://github.com/nephila/django-knocker
 .. _Beatserver: https://github.com/rajasimon/beatserver
 .. _cq: https://github.com/furious-luke/django-cq
+.. _Debugpannel: https://github.com/Krukov/django-channels-panel


### PR DESCRIPTION
As usual it is proof of concept
I tested it only at two example projects and it worked. :smile: 