### PR TITLE
Fixed bug with _binding_group_names

### DIFF
--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -86,7 +86,6 @@ class Binding(object):
         with cls.lock:
             cls._old_group_names = group_names
 
-
     @classmethod
     def register(cls):
         """

--- a/channels/binding/base.py
+++ b/channels/binding/base.py
@@ -71,7 +71,7 @@ class Binding(object):
     # Decorators
     channel_session_user = True
     channel_session = False
-    
+
     old_group_names = set()
 
     @classmethod


### PR DESCRIPTION
Since the old_group_names were saved as an attribute of ``instance`` in the ``pre_change_receiver`` it did not carry over to ``post_change_receiver`` and an ``AttributeError`` was raised. I think that saving ``old_group_names`` as a class attribute of the binding is the best fix for this.