### PR TITLE
Added a `"` to close the line

### DIFF
--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -506,7 +506,7 @@ routing our chat from above::
     ]
 
     chat_routing = [
-        route("websocket.connect", chat_connect, path=r"^/(?P<room>[a-zA-Z0-9_]+)/$),
+        route("websocket.connect", chat_connect, path=r"^/(?P<room>[a-zA-Z0-9_]+)/$"),
         route("websocket.disconnect", chat_disconnect),
     ]
 


### PR DESCRIPTION
You may also want to make use of:

```rst
.. code:: python
```

instead of just `::`.  Sphinx will then do the colour highlighting for you and may have helped catch this.

Ooh, and also, it wasn't immediately obvious to me here that `include` is imported from `from channels.routing`.  You may want to add that to the code sample.